### PR TITLE
chore: Minor change to remove www from github url in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ keywords    = ["collection", "skiplist", "sorted"]
 
 documentation = "https://docs.rs/skiplist"
 homepage      = "https://www.jpellis.me/projects/rust-skiplist/"
-repository    = "https://www.github.com/normano/rust-skiplist/"
+repository    = "https://github.com/normano/rust-skiplist/"
 
 readme = "README.md"
 


### PR DESCRIPTION
Github redirects to the address without www anyway, so let's put that in Cargo.toml See also https://github.com/szabgab/rust-digger/issues/96
You can find out info about all of your crates here: https://rust-digger.code-maven.com/users/normano